### PR TITLE
跨域请求需求

### DIFF
--- a/annie/net/URLLoader.ts
+++ b/annie/net/URLLoader.ts
@@ -83,7 +83,7 @@ namespace annie {
             if (s.responseType == "image" || s.responseType == "sound" || s.responseType == "video") {
                 req.responseType = "blob";
             }
-            req.withCredentials = true;
+            req.withCredentials = false;
             if (!s.data) {
                 req.send();
             } else {


### PR DESCRIPTION
当withCredentials=true时，泛型跨域设置将不能使用（Access-Control-Allow-Origin:
*），因此改为false。
